### PR TITLE
Fix Segment Duplication Bug

### DIFF
--- a/Assets/Scripts/Tracks/TrackManager.cs
+++ b/Assets/Scripts/Tracks/TrackManager.cs
@@ -497,6 +497,7 @@ public class TrackManager : MonoBehaviour
 
         int segmentUse = Random.Range(0, m_CurrentThemeData.zones[m_CurrentZone].prefabList.Length);
         if (segmentUse == m_PreviousSegment) segmentUse = (segmentUse + 1) % m_CurrentThemeData.zones[m_CurrentZone].prefabList.Length;
+        m_PreviousSegment = segmentUse;
 
         AsyncOperationHandle segmentToUseOp = m_CurrentThemeData.zones[m_CurrentZone].prefabList[segmentUse].InstantiateAsync(_offScreenSpawnPos, Quaternion.identity);
         yield return segmentToUseOp;


### PR DESCRIPTION
In `Assets/Scripts/Tracks/TrackManager.cs` at line `499` we have:
`if (segmentUse == m_PreviousSegment) segmentUse = (segmentUse + 1) % m_CurrentThemeData.zones[m_CurrentZone].prefabList.Length;`
If my assumption is correct then this checks whether new random index `segmentUse` is the same as previous segment index `m_PreviousSegment` and if it's true, then `segmentUse` gets incremented by 1 and modulo to loop through if necessary.
But the thing is we don't update `m_PreviousSegment` nowhere. It's always equal to `-1` since it was initialized it at line `111`.